### PR TITLE
Force TLS version to 1.2

### DIFF
--- a/Chapter13/ConsoleChannel/Authenticate.cs
+++ b/Chapter13/ConsoleChannel/Authenticate.cs
@@ -21,6 +21,7 @@ namespace ConsoleChannel
                 "Type \"/exit\" to end the program\n");
             Message.WritePrompt();
 
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             string secret = ConfigurationManager.AppSettings["DirectLineSecretKey"];
             var client = new DirectLineClient(secret);
             Conversation conversation =


### PR DESCRIPTION
Specify TLS version to 1.2, otherwise, the connection will fail since December 4th, 2018 (see: https://azure.microsoft.com/en-us/updates/azure-bot-service-enforcing-transport-layer-security-tls-1-2/)